### PR TITLE
Shooter angle abs encoder

### DIFF
--- a/ted/src/main/java/frc/robot/control/Constants.java
+++ b/ted/src/main/java/frc/robot/control/Constants.java
@@ -151,7 +151,7 @@ public final class Constants {
     // TODO depending on which side the motor is mounted, may need to invert these.
     public static InvertedValue angleLeftTalonShooterMotorDefaultDirection = InvertedValue.CounterClockwise_Positive;
     public static InvertedValue angleRightTalonShooterMotorDefaultDirection = InvertedValue.Clockwise_Positive;
-    public static final double shooterAbsoluteAngleOffsetDegrees = 58.5;
+    public static final double shooterAbsoluteAngleOffsetDegrees = 58.5 + 1.16 - 0.215;
     public static final double shooterStartingAngleOffsetDegrees = 20.0; 
     public static SensorDirectionValue shooterAngleSensorDirection = SensorDirectionValue.CounterClockwise_Positive;
     public static final double shooterAngleMaxDegrees = 110;

--- a/ted/src/main/java/frc/robot/control/Constants.java
+++ b/ted/src/main/java/frc/robot/control/Constants.java
@@ -151,7 +151,7 @@ public final class Constants {
     // TODO depending on which side the motor is mounted, may need to invert these.
     public static InvertedValue angleLeftTalonShooterMotorDefaultDirection = InvertedValue.CounterClockwise_Positive;
     public static InvertedValue angleRightTalonShooterMotorDefaultDirection = InvertedValue.Clockwise_Positive;
-    public static final double shooterAbsoluteAngleOffsetDegrees = 58.5 + 1.16 - 0.215;
+    public static final double shooterAbsoluteAngleOffsetDegrees = 59.445;
     public static final double shooterStartingAngleOffsetDegrees = 20.0; 
     public static SensorDirectionValue shooterAngleSensorDirection = SensorDirectionValue.CounterClockwise_Positive;
     public static final double shooterAngleMaxDegrees = 110;

--- a/ted/src/main/java/frc/robot/control/InstalledHardware.java
+++ b/ted/src/main/java/frc/robot/control/InstalledHardware.java
@@ -66,8 +66,8 @@ public class InstalledHardware
     // for testing, to decrease the power of the shooter angle mechanism, 
     // reduce the left motor gear box to 10x (instaed of 100x)
     // and disconnect the right motor from the chain. 
-    public static final boolean shooterRightAngleMotorrInstalled = false;
-    public static final boolean shooterAngleCanCoderInstalled = false; 
+    public static final boolean shooterRightAngleMotorrInstalled = true;
+    public static final boolean shooterAngleCanCoderInstalled = true; 
 
     // Climber Sensor Related Hardware
     public static final boolean leftClimberInstalled = true;

--- a/ted/src/main/java/frc/robot/control/InstalledHardware.java
+++ b/ted/src/main/java/frc/robot/control/InstalledHardware.java
@@ -66,7 +66,7 @@ public class InstalledHardware
     // for testing, to decrease the power of the shooter angle mechanism, 
     // reduce the left motor gear box to 10x (instaed of 100x)
     // and disconnect the right motor from the chain. 
-    public static final boolean shooterRightAngleMotorrInstalled = true;
+    public static final boolean shooterRightAngleMotorrInstalled = false;
     public static final boolean shooterAngleCanCoderInstalled = false; 
 
     // Climber Sensor Related Hardware

--- a/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
+++ b/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
@@ -52,7 +52,12 @@ public class ShooterAngleSubsystem extends SubsystemBase {
   private double internalAngleOffsetDegrees = 0; // used when running from intenral motor encoder, ignored when using CanCoder
 
   // Motor controller gains
-  private Slot0Configs angleMotorGains = new Slot0Configs().withKP(350).withKI(0).withKD(50.0).withKV(0);
+  // good settings for running from the internal motor controller
+  // private Slot0Configs angleMotorGains = new Slot0Configs().withKP(350).withKI(0).withKD(50.0).withKV(0);
+  // settings for running form the absolute encoder
+  // single motor
+  // private Slot0Configs angleMotorGains = new Slot0Configs().withKP(175).withKI(0.125).withKD(0.05).withKV(0);
+  private Slot0Configs angleMotorGains = new Slot0Configs().withKP(150).withKI(0.125).withKD(0.05).withKV(0);
 
   /**
    * Constructor for shooter subsystem

--- a/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
+++ b/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
@@ -37,8 +37,8 @@ import frc.robot.common.ShooterPosition;
 public class ShooterAngleSubsystem extends SubsystemBase {
 
   // Shooter gearing 
-  // private static final double angleMotorGearRatio = 450.0; // 450:1 (100:1 -> 72:16) 
-  private static final double angleMotorGearRatio = 45.0; // remove 1 10x gearbox stage for testing
+  private static final double angleMotorGearRatio = 450.0; // 450:1 (100:1 -> 72:16) 
+  //private static final double angleMotorGearRatio = 45.0; // remove 1 10x gearbox stage for testing
   private static final double angleEncoderGearRatio = 1.0; // angle encoder is mounted directly onto shaft
   private static final double shooterAngleLowVelocityTol = 10; // rotations per second (max 512)
 

--- a/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
+++ b/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
@@ -37,8 +37,8 @@ import frc.robot.common.ShooterPosition;
 public class ShooterAngleSubsystem extends SubsystemBase {
 
   // Shooter gearing 
-  private static final double angleMotorGearRatio = 450.0; // 450:1 (100:1 -> 72:16) 
-  //private static final double angleMotorGearRatio = 45.0; // remove 1 10x gearbox stage for testing
+  // private static final double angleMotorGearRatio = 450.0; // 450:1 (100:1 -> 72:16) 
+  private static final double angleMotorGearRatio = 45.0; // remove 1 10x gearbox stage for testing
   private static final double angleEncoderGearRatio = 1.0; // angle encoder is mounted directly onto shaft
   private static final double shooterAngleLowVelocityTol = 10; // rotations per second (max 512)
 

--- a/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
+++ b/ted/src/main/java/frc/robot/subsystems/ShooterAngleSubsystem.java
@@ -52,12 +52,8 @@ public class ShooterAngleSubsystem extends SubsystemBase {
   private double internalAngleOffsetDegrees = 0; // used when running from intenral motor encoder, ignored when using CanCoder
 
   // Motor controller gains
-  // good settings for running from the internal motor controller
-  // private Slot0Configs angleMotorGains = new Slot0Configs().withKP(350).withKI(0).withKD(50.0).withKV(0);
-  // settings for running form the absolute encoder
-  // single motor
-  // private Slot0Configs angleMotorGains = new Slot0Configs().withKP(175).withKI(0.125).withKD(0.05).withKV(0);
-  private Slot0Configs angleMotorGains = new Slot0Configs().withKP(150).withKI(0.125).withKD(0.05).withKV(0);
+  private Slot0Configs angleMotorGainsForInternalEncoder = new Slot0Configs().withKP(350).withKI(0).withKD(50.0).withKV(0);
+  private Slot0Configs angleMotorGainsForAbsoluteEncoder = new Slot0Configs().withKP(150).withKI(0.125).withKD(0.05).withKV(0);
 
   /**
    * Constructor for shooter subsystem
@@ -191,9 +187,9 @@ public class ShooterAngleSubsystem extends SubsystemBase {
     angleConfigs.MotorOutput.NeutralMode = NeutralModeValue.Brake;
     angleConfigs.MotorOutput.Inverted = Constants.angleLeftTalonShooterMotorDefaultDirection;
     // FeedbackConfigs and offsets
-    angleConfigs.Slot0 = angleMotorGains;
     if (InstalledHardware.shooterAngleCanCoderInstalled) {
       System.out.println("Configuring Shooter Angle Motor with CanCoder Feedback.");
+      angleConfigs.Slot0 = angleMotorGainsForAbsoluteEncoder;
       angleConfigs.Feedback.SensorToMechanismRatio = angleEncoderGearRatio;
       angleConfigs.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.RemoteCANcoder;
       angleConfigs.Feedback.FeedbackRemoteSensorID = Constants.shooterLeftAngleEncoderCanId;
@@ -201,6 +197,7 @@ public class ShooterAngleSubsystem extends SubsystemBase {
     } 
     else {
       System.out.println("Configuring Shooter Angle Motor with Internal Encoder Feedback.");
+      angleConfigs.Slot0 = angleMotorGainsForInternalEncoder;
       angleConfigs.Feedback.SensorToMechanismRatio = angleMotorGearRatio;
       angleConfigs.Feedback.FeedbackSensorSource = FeedbackSensorSourceValue.RotorSensor; // the internal encoder
     }


### PR DESCRIPTION
Shooter runs from absolute encoder. Re-dialed PIDs. Created alternate set of PIDs for running from internal motor encoder vs. absolute encoder.  Tested and works on robot. Testing included starting at a random angle and seeing that the motor encoder was seeded with the correct angle. 